### PR TITLE
Hide strnlen() when building with MAC_OS_X >= 10.7.

### DIFF
--- a/config-compat-darwin.h
+++ b/config-compat-darwin.h
@@ -38,6 +38,7 @@ static inline char *dcgettext (char *__domainname, char *__msgid, int __category
 	return NULL;
 }
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1070
 static inline size_t strnlen (const char *__string, size_t __maxlen)
 {
 	int len = 0;
@@ -45,6 +46,7 @@ static inline size_t strnlen (const char *__string, size_t __maxlen)
 		len++;
 	return len;
 }
+#endif
 
 static inline void *mempcpy (void * __dest, const void * __src, size_t __n)
 {


### PR DESCRIPTION
strnlen() is defined in osx 10.7 and later but not in previous version. The definition causes a conflict in osx 10.7 and later.
